### PR TITLE
Set LEIN_JVM_OPTS based on build in environment variables

### DIFF
--- a/env/LEIN_JVM_OPTS.erb
+++ b/env/LEIN_JVM_OPTS.erb
@@ -1,1 +1,1 @@
--Duser.home=<%= ENV['LEIN_HOME'] %>
+-Duser.home=<%= ENV['OPENSHIFT_CLOJURE_DIR'] %>/home


### PR DESCRIPTION
Setting `LEIN_JVM_OPTS` based on `LEIN_HOME` didn't work, as `LEIN_JVM_OPTS` was `--Duser.home=`. It could be that `LEIN_HOME` was not initialized before `LEIN_JVM_OPTS`.

Please review.