### PR TITLE
fix $LEIN_JVM_OPTS doesn't work

### DIFF
--- a/env/LEIN_JVM_OPTS.erb
+++ b/env/LEIN_JVM_OPTS.erb
@@ -1,1 +1,1 @@
--Duser.home=<%= ENV['LEIN_HOME'] %>
+-Duser.home=<%= ENV['OPENSHIFT_CLOJURE_DIR'] %>


### PR DESCRIPTION
I have solved the problem.
```
$ rhc tail -a myapp                                                                                                                                                                      (git)-[master]
Downloading Leiningen to /var/lib/openshift/561a94537628e1aa700000e1/clojure//home/self-installs/leiningen-2.5.3-standalone.jar now...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15.0M  100 15.0M    0     0  13.9M      0  0:00:01  0:00:01 --:--:-- 13.9M
Could not transfer artifact lein-ring:lein-ring:pom:0.7.5 from/to clojars (https://clojars.org/repo/): Specified destination directory cannot be created: /.m2/repository/lein-ring/lein-ring/0.7.5
This could be due to a typo in :dependencies or network issues.
If you are behind a proxy, try setting the 'http_proxy' environment variable.
```